### PR TITLE
2.13.3: fix Ruby <2.6 combine_paths slice; load xqsr3 in warnings CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -101,4 +101,4 @@ jobs:
       run: ruby -v
 
     - name: Run unit tests with warnings
-      run: ./run_all_unit_tests.sh --lib --warnings
+      run: bundle exec ./run_all_unit_tests.sh --lib --warnings

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 * fixed **recls.gemspec** homepage/metadata to **recls.Ruby** (HTTPS);
 * fixed `Recls.combine_paths` array slice to remain compatible with Ruby 1.9.3–2.5 (no endless ranges);
 * warnings CI job now runs via `bundle exec` so development gems (e.g. **xqsr3**) are loadable;
+* Ruby 4+ (incl. MinGW): pull in **fiddle** from the **Gemfile** (no longer a default gem; still required on Windows);
+* documented the Ruby 4+ Windows **fiddle** requirement in **README.md** (**Installation** and **Dependencies**);
 
 
 ## 2.13.2 - 25th April 2025

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 * warnings CI job now runs via `bundle exec` so development gems (e.g. **xqsr3**) are loadable;
 * Ruby 4+ (incl. MinGW): pull in **fiddle** from the **Gemfile** (no longer a default gem; still required on Windows);
 * documented the Ruby 4+ Windows **fiddle** requirement in **README.md** (**Installation** and **Dependencies**);
+* Ruby 4+ (incl. MinGW): `Recls::Ximpl::FileStat` no longer subclasses `File::Stat` (avoids `TypeError: wrong instance allocation`);
 
 
 ## 2.13.2 - 25th April 2025

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,23 +1,20 @@
 # **recls.Ruby** Changes <!-- omit in toc -->
 
 
-## 2.13.2.1 - 13th August 2026
+## 2.13.3 - 13th August 2026
 
 * documentation and project-boilerplate modernisation;
 * added **AUTHORS.md**, **NEWS.md**, and **TODO.md**;
 * completed **.github/workflows/ruby.yml** (OS × Ruby matrix, gem smoke, warnings job);
 * implemented **Rakefile** `test` / `default` tasks;
 * fixed **recls.gemspec** homepage/metadata to **recls.Ruby** (HTTPS);
+* fixed `Recls.combine_paths` array slice to remain compatible with Ruby 1.9.3–2.5 (no endless ranges);
+* warnings CI job now runs via `bundle exec` so development gems (e.g. **xqsr3**) are loadable;
 
 
 ## 2.13.2 - 25th April 2025
 
 * fixed `Recls.combine_paths` for combining `Recls::Entry` instance(s) that may be directories;
-
-
-## 2.13.2 - 25th April 2025
-
-* Fixed `Recls.combine_paths()` such that passing a `Recls::Entry` that represents a directory is not taken to be the complete result, as is (and should be) the case for a file;
 
 
 ## 2.13.1 - 2nd June 2024

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,14 @@ source "https://rubygems.org"
 
 gemspec
 
+# fiddle left the default-gem set in Ruby 4; Windows (Ruby 2+) requires it
+# via lib/recls/ximpl/windows.rb. Not declared in the gemspec: the fiddle
+# gem itself requires Ruby >= 2.5 and would break resolution on 1.9.3–2.4.
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('4')
+
+  gem 'fiddle', '~> 1.0'
+end
+
 # rake 13 requires Ruby >= 2.3
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.3")
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 | Date               | News Item                   |
 | ------------------ | --------------------------- |
-| 13th August 2026   | [**recls.Ruby** 2.13.2.1](https://github.com/synesissoftware/recls.Ruby/releases/tag/2.13.2.1) |
+| 13th August 2026   | [**recls.Ruby** 2.13.3](https://github.com/synesissoftware/recls.Ruby/releases/tag/2.13.3) |
 | 25th April 2025    | [**recls.Ruby** 2.13.2](https://github.com/synesissoftware/recls.Ruby/releases/tag/2.13.2) |
 | 2nd June 2024      | [**recls.Ruby** 2.13.1](https://github.com/synesissoftware/recls.Ruby/releases/tag/2.13.1) |
 | 20th April 2024    | [**recls.Ruby** 2.13.0](https://github.com/synesissoftware/recls.Ruby/releases/tag/2.13.0) |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ gem install recls-ruby
 
 or add it to your `Gemfile`.
 
+> **NOTE**: On **Windows** with **Ruby 4+**, also install [**fiddle**](https://rubygems.org/gems/fiddle) (`gem install fiddle`, or `gem 'fiddle'` in your Gemfile). See [Runtime Dependencies](#runtime-dependencies-aka-normal-dependencies).
+
 
 ## Components
 
@@ -312,7 +314,9 @@ Libraries upon which **recls.Ruby** depends:
 
 ##### Runtime Dependencies (aka "Normal Dependencies")
 
-* \<none>;
+* \<none> declared in **recls.gemspec**;
+
+> **NOTE**: On **Windows** with **Ruby 4+**, **fiddle** is required at runtime (`lib/recls/ximpl/windows.rb`) but is no longer a default gem and is not listed in **recls.gemspec** (so older Rubies in the `[1.9.3, 4)` range still resolve). Install it explicitly, e.g. `gem install fiddle`, or add `gem 'fiddle'` to your Gemfile. This repository’s **Gemfile** pulls it in when `RUBY_VERSION >= '4'`.
 
 
 ##### Development Dependencies

--- a/lib/recls/combine_paths_1.rb
+++ b/lib/recls/combine_paths_1.rb
@@ -4,7 +4,7 @@
 # Purpose:  Definition of Recls::compare_paths() for Ruby 1.x
 #
 # Created:  17th February 2014
-# Updated:  9th January 2025
+# Updated:  13th August 2026
 #
 # Author:   Matthew Wilson
 #
@@ -77,7 +77,7 @@ module Recls
 
       if fe.directory?
 
-        paths = paths[ix_last_entry..]
+        paths = paths[ix_last_entry..-1]
       else
 
         return fe

--- a/lib/recls/combine_paths_2plus.rb
+++ b/lib/recls/combine_paths_2plus.rb
@@ -4,7 +4,7 @@
 # Purpose:  Definition of Recls::compare_paths() for Ruby 2+
 #
 # Created:  17th February 2014
-# Updated:  9th January 2025
+# Updated:  13th August 2026
 #
 # Author:   Matthew Wilson
 #
@@ -83,7 +83,7 @@ module Recls
 
       if fe.directory?
 
-        paths = paths[ix_last_entry..]
+        paths = paths[ix_last_entry..-1]
       else
 
         return fe

--- a/lib/recls/file_search.rb
+++ b/lib/recls/file_search.rb
@@ -4,7 +4,7 @@
 # Purpose:  Defines the Recls::FileSearch class for the recls.Ruby library.
 #
 # Created:  24th July 2012
-# Updated:  21st April 2024
+# Updated:  13th August 2026
 #
 # Author:   Matthew Wilson
 #
@@ -203,7 +203,7 @@ module Recls
       rescue Errno::ENOENT, Errno::ENXIO
 
         nil
-      rescue SystemCallError => x
+      rescue SystemCallError
 
         # TODO this should be filtered up and/or logged
 

--- a/lib/recls/version.rb
+++ b/lib/recls/version.rb
@@ -43,7 +43,7 @@
 module Recls
 
   # Current version of the recls.Ruby library
-  VERSION           = '2.13.2.1'
+  VERSION           = '2.13.3'
 
   private
   # @!visibility private

--- a/lib/recls/ximpl/unix.rb
+++ b/lib/recls/ximpl/unix.rb
@@ -4,11 +4,11 @@
 # Purpose:  UNIX-specific constructs for the recls library.
 #
 # Created:  19th February 2014
-# Updated:  21st April 2024
+# Updated:  13th August 2026
 #
 # Author:   Matthew Wilson
 #
-# Copyright (c) 2019-2024, Matthew Wilson and Synesis Information Systems
+# Copyright (c) 2019-2026, Matthew Wilson and Synesis Information Systems
 # Copyright (c) 2012-2019, Matthew Wilson and Synesis Software
 # All rights reserved.
 #
@@ -48,15 +48,19 @@ module Recls
   # @!visibility private
   module Ximpl # :nodoc: all
 
+    # File::Stat cannot reliably be subclassed on all Rubies (notably some
+    # Ruby 4 / MinGW builds raise TypeError: wrong instance allocation).
+    # Compose instead and forward File::Stat APIs via method_missing.
+    #
     # @!visibility private
-    class FileStat < File::Stat # :nodoc:
+    class FileStat # :nodoc:
 
       private
       def initialize(path)
 
         @path = path
 
-        super(path)
+        @stat = ::File::Stat.new(path)
       end
 
       public
@@ -72,6 +76,16 @@ module Recls
         return false if ?. != basename[0]
 
         return true
+      end
+
+      def method_missing(name, *args, &block)
+
+        @stat.__send__(name, *args, &block)
+      end
+
+      def respond_to_missing?(name, include_all = false)
+
+        @stat.respond_to?(name, include_all) || super
       end
 
       public

--- a/lib/recls/ximpl/util.rb
+++ b/lib/recls/ximpl/util.rb
@@ -4,11 +4,11 @@
 # Purpose:  Internal implementation constructs for the recls library.
 #
 # Created:  24th July 2012
-# Updated:  21st April 2024
+# Updated:  13th August 2026
 #
 # Author:   Matthew Wilson
 #
-# Copyright (c) 2019-2024, Matthew Wilson and Synesis Information Systems
+# Copyright (c) 2019-2026, Matthew Wilson and Synesis Information Systems
 # Copyright (c) 2012-2019, Matthew Wilson and Synesis Software
 # All rights reserved.
 #
@@ -501,7 +501,12 @@ module Recls
 
       f1_windows_root, f2_directory, dummy1, dummy2, dummy3, dummy4, dummy5 = Util.split_path(path)
 
-      dummy1 = dummy2 = dummy3 = dummy4 = dummy5 = nil
+      # suppress unused warnings
+      dummy1 = dummy1
+      dummy2 = dummy2
+      dummy3 = dummy3
+      dummy4 = dummy4
+      dummy5 = dummy5
 
       unless f1_windows_root
 

--- a/lib/recls/ximpl/windows.rb
+++ b/lib/recls/ximpl/windows.rb
@@ -4,11 +4,11 @@
 # Purpose:  Windows-specific constructs for the recls library.
 #
 # Created:  19th February 2014
-# Updated:  2nd June 2024
+# Updated:  13th August 2026
 #
 # Author:   Matthew Wilson
 #
-# Copyright (c) 2019-2024, Matthew Wilson and Synesis Information Systems
+# Copyright (c) 2019-2026, Matthew Wilson and Synesis Information Systems
 # Copyright (c) 2012-2019, Matthew Wilson and Synesis Software
 # All rights reserved.
 #
@@ -39,8 +39,15 @@
 
 if RUBY_VERSION >= '2'
 
-  require 'fiddle'
-  require 'fiddle/import'
+  begin
+
+    require 'fiddle'
+    require 'fiddle/import'
+  rescue LoadError => e
+
+    # Ruby 4+ no longer ships fiddle as a default gem.
+    raise LoadError, "#{e.message}; on Ruby 4+ Windows, add the 'fiddle' gem (see the project Gemfile)"
+  end
 else
 
   require 'Win32API'

--- a/lib/recls/ximpl/windows.rb
+++ b/lib/recls/ximpl/windows.rb
@@ -218,8 +218,12 @@ module Recls
       end # module Kernel32
     end
 
+    # File::Stat cannot reliably be subclassed on all Rubies (notably some
+    # Ruby 4 / MinGW builds raise TypeError: wrong instance allocation).
+    # Compose instead and forward File::Stat APIs via method_missing.
+    #
     # @!visibility private
-    class FileStat < File::Stat # :nodoc:
+    class FileStat # :nodoc:
 
       private
       FILE_ATTRIBUTE_READONLY     = 0x00000001
@@ -267,7 +271,7 @@ module Recls
 
         @attributes = Kernel32.get_file_attributes(path)
 
-        super(path)
+        @stat = ::File::Stat.new(path)
 
         @by_handle_information = ByHandleInformation.new(path)
 
@@ -335,6 +339,17 @@ module Recls
         has_attribute_? FILE_ATTRIBUTE_ENCRYPTED
       end
 
+      # @!visibility private
+      def method_missing(name, *args, &block) # :nodoc:
+
+        @stat.__send__(name, *args, &block)
+      end
+
+      # @!visibility private
+      def respond_to_missing?(name, include_all = false) # :nodoc:
+
+        @stat.respond_to?(name, include_all) || super
+      end
 
       public
       # @!visibility private

--- a/test/unit/util/tc_combine_paths.rb
+++ b/test/unit/util/tc_combine_paths.rb
@@ -113,7 +113,6 @@ class Test_combine_paths < Test::Unit::TestCase
 
     f_g = Recls.stat('/f/g', Recls::DETAILS_LATER | Recls::DIRECTORIES)
     b = Recls.stat('b', Recls::DETAILS_LATER | Recls::DIRECTORIES)
-    root_b = Recls.stat('/b', Recls::DETAILS_LATER | Recls::DIRECTORIES)
 
     assert_equal '/a/b/c/d/e/f/g', Recls.combine_paths('/', 'a', 'b', 'c', 'd/e', 'f/g')
     assert_equal '/f/g', Recls.combine_paths('/', 'a', 'b', 'c', 'd/e', '/f/g')


### PR DESCRIPTION
Replace endless-range syntax so 1.9.3–2.5 still parse, run the warnings job under bundle exec, and quiet unused-variable warnings under -w.